### PR TITLE
Fix build issues due to libssh bug

### DIFF
--- a/depends/common/libssh/11-libssh-fix.patch
+++ b/depends/common/libssh/11-libssh-fix.patch
@@ -1,0 +1,11 @@
+--- a/src/connect.c
++++ b/src/connect.c
+@@ -476,7 +476,7 @@ int ssh_select(ssh_channel *channels, ssh_channel *outchannels, socket_t maxfd,
+     fd_set *readfds, struct timeval *timeout) {
+   fd_set origfds;
+   socket_t fd;
+-  int i,j;
++  size_t i,j;
+   int rc;
+   int base_tm, tm;
+   struct ssh_timestamp ts;


### PR DESCRIPTION
libssh not longer builds after bump to version 0.8.4

 Found a fix for this. Its a bug in libssh. There is a patch which I have applied to my libssh 0.8.4 and it fixes the issue.

https://bugs.libssh.org/T126